### PR TITLE
Workshop explosion

### DIFF
--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -16,4 +16,5 @@ path = "tests/progress.rs"
 workshop-test-runner = { path = "../test-runner" }
 
 [dependencies]
-# TODO
+syn = { version="0.15", features=["derive"]}
+quote = "0.6"

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -1,10 +1,19 @@
 extern crate proc_macro;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
 
 use proc_macro::TokenStream;
 
 #[proc_macro_derive(Builder)]
 pub fn derive(input: TokenStream) -> TokenStream {
-    let _ = input;
+    // Parse the input tokens into a syntax tree
+    let input = parse_macro_input!(input as DeriveInput);
 
-    unimplemented!()
+    // Build the output, possibly using quasi-quotation
+    let expanded = quote! {
+        // ...
+    };
+
+    // Hand the output tokens back to the compiler
+    TokenStream::from(expanded)
 }

--- a/builder/tests/progress.rs
+++ b/builder/tests/progress.rs
@@ -1,7 +1,7 @@
 #[test]
 fn tests() {
     let t = workshop::TestCases::new();
-    //t.pass("tests/01-parse.rs");
+    t.pass("tests/01-parse.rs");
     //t.pass("tests/02-create-builder.rs");
     //t.pass("tests/03-call-setters.rs");
     //t.pass("tests/04-call-build.rs");

--- a/test-runner/src/run.rs
+++ b/test-runner/src/run.rs
@@ -17,8 +17,9 @@ const IGNORED_LINTS: &[&str] = &["dead_code"];
 impl Runner {
     pub fn run(&mut self) {
         if let Err(err) = self.prepare() {
+            let message = format!("tests failed: {}", err);
             message::prepare_fail(err);
-            panic!("tests failed");
+            panic!(message);
         }
 
         println!();


### PR DESCRIPTION
```
Xaviers-MacBook-Pro:builder xavierlange$ cargo test
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running target/debug/deps/derive_builder-16c8f906a9fa68bb

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/tests-45f06052a8da4d60

running 1 test
   Compiling derive_builder-tests v0.0.0 (/Users/xavierlange/code/rust/proc-macro-workshop/builder/target/tests)
error: failed to link or copy `/Users/xavierlange/code/rust/proc-macro-workshop/builder/target/tests/target/debug/deps/derive_builder_tests-509bcdac6c5bfe30.dSYM` to `/Users/xavierlange/code/rust/proc-macro-workshop/builder/target/tests/target/debug/derive_builder-tests.dSYM`

Caused by:
  the source path is not an existing regular file
test tests ... FAILED

failures:

---- tests stdout ----
thread 'tests' panicked at 'tests failed: cargo reported an error', /Users/xavierlange/code/rust/proc-macro-workshop/test-runner/src/run.rs:22:13
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.


failures:
    tests

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out

error: test failed, to rerun pass '--test tests'
```