### PR TITLE
Move all crates into the same workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.0.0"
 edition = "2018"
 publish = false
 
+[workspace]
+
 [[bin]]
 name = "workshop"
 path = "main.rs"

--- a/test-runner/src/cargo.rs
+++ b/test-runner/src/cargo.rs
@@ -1,11 +1,27 @@
 use std::env;
 use std::process::{Command, Output};
+use std::path::PathBuf;
 
 use crate::error::{Error, Result};
 
+pub fn target_dir() -> Result<PathBuf> {
+    let mut target_dir = env::current_dir()?;
+    target_dir.pop(); // chop off our crate name
+    target_dir.push("target");
+    assert!(target_dir.exists());
+    Ok(target_dir)
+}
+
+fn cargo() -> Result<Command> {
+    let mut cmd = Command::new("cargo");
+    let target_dir = target_dir()?;
+    cmd.current_dir(target_dir.join("tests"))
+        .env("CARGO_TARGET_DIR", &target_dir);
+    Ok(cmd)
+}
+
 pub fn build_dependencies(project: &str) -> Result<()> {
-    let status = Command::new("cargo")
-        .current_dir("target/tests")
+    let status = cargo()?
         .arg("build")
         .arg("--bin")
         .arg(project)
@@ -22,8 +38,7 @@ pub fn build_dependencies(project: &str) -> Result<()> {
 pub fn build_test(name: &str) -> Result<Output> {
     if let Ok(crate_name) = env::var("CARGO_PKG_NAME") {
         let project = format!("{}-tests", crate_name);
-        let _ = Command::new("cargo")
-            .current_dir("target/tests")
+        let _ = cargo()?
             .arg("clean")
             .arg("--package")
             .arg(project)
@@ -31,8 +46,7 @@ pub fn build_test(name: &str) -> Result<Output> {
             .status();
     }
 
-    Command::new("cargo")
-        .current_dir("target/tests")
+    cargo()?
         .arg("build")
         .arg("--bin")
         .arg(name)
@@ -43,8 +57,7 @@ pub fn build_test(name: &str) -> Result<Output> {
 }
 
 pub fn run_test(name: &str) -> Result<Output> {
-    Command::new("cargo")
-        .current_dir("target/tests")
+    cargo()?
         .arg("run")
         .arg("--bin")
         .arg(name)

--- a/test-runner/src/manifest.rs
+++ b/test-runner/src/manifest.rs
@@ -9,6 +9,7 @@ pub struct Manifest {
     pub dependencies: Map<String, Dependency>,
     #[serde(rename = "bin")]
     pub bins: Vec<Bin>,
+    pub workspace: Option<Workspace>,
 }
 
 #[derive(Serialize)]
@@ -49,4 +50,8 @@ pub struct Config {
 #[derive(Serialize)]
 pub struct Build {
     pub rustflags: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct Workspace {
 }

--- a/test-runner/src/run.rs
+++ b/test-runner/src/run.rs
@@ -2,13 +2,13 @@ use std::collections::BTreeMap as Map;
 use std::env;
 use std::ffi::OsStr;
 use std::fs::{self, File};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use super::{Expected, Runner, Test};
 use crate::banner;
 use crate::cargo;
 use crate::error::{Error, Result};
-use crate::manifest::{Bin, Dependency, Edition, Manifest, Package, Config, Build};
+use crate::manifest::{Bin, Dependency, Edition, Manifest, Package, Config, Build, Workspace};
 use crate::message;
 use crate::normalize;
 
@@ -49,21 +49,22 @@ impl Runner {
         let crate_name = env::var("CARGO_PKG_NAME").map_err(Error::PkgName)?;
         let project = format!("{}-tests", crate_name);
 
-        let manifest = self.make_manifest(crate_name, &project);
+        let manifest = self.make_manifest(crate_name, &project)?;
         let manifest_toml = toml::to_string(&manifest)?;
 
         let config = self.make_config();
         let config_toml = toml::to_string(&config)?;
 
-        fs::create_dir_all("target/tests/.cargo")?;
-        fs::write("target/tests/Cargo.toml", manifest_toml)?;
-        fs::write("target/tests/.cargo/config", config_toml)?;
-        fs::write("target/tests/main.rs", b"fn main() {}\n")?;
+        let target_dir = cargo::target_dir()?;
+        fs::create_dir_all(target_dir.join("tests/.cargo"))?;
+        fs::write(target_dir.join("tests/Cargo.toml"), manifest_toml)?;
+        fs::write(target_dir.join("tests/.cargo/config"), config_toml)?;
+        fs::write(target_dir.join("tests/main.rs"), b"fn main() {}\n")?;
 
         cargo::build_dependencies(&project)
     }
 
-    fn make_manifest(&self, crate_name: String, project: &str) -> Manifest {
+    fn make_manifest(&self, crate_name: String, project: &str) -> Result<Manifest> {
         let mut manifest = Manifest {
             package: Package {
                 name: project.to_owned(),
@@ -73,13 +74,16 @@ impl Runner {
             },
             dependencies: Map::new(),
             bins: Vec::new(),
+            workspace: Some(Workspace {}),
         };
+
+        let cwd = env::current_dir()?;
 
         manifest.dependencies.insert(
             crate_name,
             Dependency {
                 version: None,
-                path: Some("../..".to_owned()),
+                path: Some(cwd.display().to_string()),
                 features: Vec::new(),
             },
         );
@@ -100,11 +104,11 @@ impl Runner {
         for test in &self.tests {
             manifest.bins.push(Bin {
                 name: test.name(),
-                path: test.source_path(),
+                path: cwd.join(&test.path),
             });
         }
 
-        manifest
+        Ok(manifest)
     }
 
     fn make_config(&self) -> Config {
@@ -129,10 +133,6 @@ impl Test {
             .to_owned()
             .to_string_lossy()
             .replace('-', "_")
-    }
-
-    fn source_path(&self) -> PathBuf {
-        Path::new("../..").join(&self.path)
     }
 
     fn run(&self) -> Result<()> {


### PR DESCRIPTION
This'll help reduce build times as the target directory is naturally
shared, and then the test cases now also have a shared target directory
with the main crate to further improve caching.