### PR TITLE
`derive(Builder)` : Unable to generate the correct error message.

### DIFF
--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -16,4 +16,5 @@ path = "tests/progress.rs"
 trybuild = "1.0"
 
 [dependencies]
-# TODO
+syn = { version = "0.15.34", features = ["extra-traits"] }
+quote = "0.6.12"

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -4,16 +4,35 @@ extern crate syn;
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput};
+use syn::{parse_macro_input, DeriveInput, Ident};
 
 #[proc_macro_derive(Builder)]
 pub fn derive(input: TokenStream) -> TokenStream {
     let ast: DeriveInput = parse_macro_input!(input as DeriveInput);
+    let name: &syn::Ident = &ast.ident;
+    let bname: String = format!("{}Builder", name);
+    let bindent: syn::Ident = Ident::new(&bname, name.span());
 
-    eprintln!("{:#?}", ast);
+    // quote::__rt::TokenStream
+    let expanded = quote! {
+        struct #bindent {
+            executable: Option<String>,
+            args: Option<Vec<String>>,
+            env: Option<Vec<String>>,
+            current_dir: Option<String>,
+        }
 
-    let expanded = quote! {};
-    let _ = TokenStream::from(expanded);
+        impl #name {
+            fn builder() -> #bindent {
+                #bindent {
+                    executable: None,
+                    args: None,
+                    env: None,
+                    current_dir: None,
+                }
+            }
+        }
+    };
 
-    TokenStream::new()
+    expanded.into()
 }

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "128"]
+
 extern crate proc_macro;
 extern crate quote;
 extern crate syn;
@@ -13,22 +15,78 @@ pub fn derive(input: TokenStream) -> TokenStream {
     let bname: String = format!("{}Builder", name);
     let bindent: syn::Ident = Ident::new(&bname, name.span());
 
+    // &syn::punctuated::Punctuated<syn::Field, syn::token::Comma>
+    // implements `IntoIter`
+    let fields = if let syn::Data::Struct(syn::DataStruct {
+        fields: syn::Fields::Named(syn::FieldsNamed { ref named, .. }),
+        ..
+    }) = ast.data
+    {
+        named
+    } else {
+        // in case the #[derive(Builder)] is put on an `enum`
+        unimplemented!();
+    };
+
+    let optionized = fields.iter().map(|f| {
+        let name = &f.ident;
+        let ty = &f.ty;
+
+        quote! {
+            #name: std::option::Option<#ty>
+        }
+    });
+
+    let methods = fields.iter().map(|f| {
+        let name = &f.ident;
+        let ty = &f.ty;
+
+        quote! {
+            pub fn #name(&mut self, #name: #ty) -> &mut Self {
+                self.#name = Some(#name);
+                self
+            }
+        }
+    });
+
+    let build_fields = fields.iter().map(|f| {
+        let name = &f.ident;
+
+        quote! {
+            #name: self.#name.clone().ok_or(concat!(stringify!(#name), " is not set"))?
+        }
+    });
+
+    let build_empty = fields.iter().map(|f| {
+        let name = &f.ident;
+
+        quote! {
+            #name: None
+        }
+    });
+
     // quote::__rt::TokenStream
     let expanded = quote! {
         struct #bindent {
-            executable: Option<String>,
-            args: Option<Vec<String>>,
-            env: Option<Vec<String>>,
-            current_dir: Option<String>,
+            #(#optionized,)*
+        }
+
+        impl #bindent {
+            #(#methods)*
+
+            pub fn build(&self) -> Result<#name, Box<dyn std::error::Error>> {
+                Ok(
+                    #name {
+                        #(#build_fields,)*
+                    }
+                )
+            }
         }
 
         impl #name {
             fn builder() -> #bindent {
                 #bindent {
-                    executable: None,
-                    args: None,
-                    env: None,
-                    current_dir: None,
+                    #(#build_empty,)*
                 }
             }
         }

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -1,10 +1,19 @@
 extern crate proc_macro;
+extern crate quote;
+extern crate syn;
 
 use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
 
 #[proc_macro_derive(Builder)]
 pub fn derive(input: TokenStream) -> TokenStream {
-    let _ = input;
+    let ast: DeriveInput = parse_macro_input!(input as DeriveInput);
 
-    unimplemented!()
+    eprintln!("{:#?}", ast);
+
+    let expanded = quote! {};
+    let _ = TokenStream::from(expanded);
+
+    TokenStream::new()
 }

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -145,14 +145,14 @@ pub fn derive(input: TokenStream) -> TokenStream {
         } else if let Some(inner_ty) = ty_inner_type("Option", ty) {
             quote! {
                 pub fn #name(&mut self, #name: #inner_ty) -> &mut Self {
-                    self.#name = Some(#name);
+                    self.#name = std::option::Option::Some(#name);
                     self
                 }
             }
         } else {
             quote! {
                 pub fn #name(&mut self, #name: #ty) -> &mut Self {
-                    self.#name = Some(#name);
+                    self.#name = std::option::Option::Some(#name);
                     self
                 }
             }
@@ -196,7 +196,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
                 .unwrap()
         } else {
             quote! {
-                #name: None
+                #name: std::option::Option::None
             }
         }
     });
@@ -210,8 +210,8 @@ pub fn derive(input: TokenStream) -> TokenStream {
         impl #bindent {
             #(#methods)*
 
-            pub fn build(&self) -> Result<#name, Box<dyn std::error::Error>> {
-                Ok(
+            pub fn build(&self) -> std::result::Result<#name, std::boxed::Box<dyn std::error::Error>> {
+                std::result::Result::Ok(
                     #name {
                         #(#build_fields,)*
                     }


### PR DESCRIPTION
When I try to do `cargo expand` `tests/08-unrecognized-attribute.rs` (copied as `main.rs`), instead of getting the error message (`expected builder(each = "...")`) created by `syn::Error::new_spanned(...)` in `field_attr_builder_each`, for some reason the error message `expected one of ...` is being generated.

```
error: expected `:`, found `!`
  --> main.rs:22:7
   |
22 |     #[builder(eac = "arg")]
   |       ^^^^^^^ expected `:`
error: expected one of `,` or `}`, found `!`
  --> main.rs:22:7
   |
20 | pub struct Command {
   |            ------- while parsing this struct
21 |     executable: String,
22 |     #[builder(eac = "arg")]
   |       ^^^^^^^ expected one of `,` or `}` here
error: aborting due to 2 previous errors
error: Could not compile `proc-macro-workshop`.
To learn more, run the command again with --verbose.
```

I can't seem to understand where this error message is originating from, and why the token stream from `err.to_compile_error()` is not being displayed instead.

 I would greatly appreciate any pointers on how I can solve this! :-)