### PR TITLE
builder test 07: add advice about duplicate method names

### DIFF
--- a/builder/tests/07-repeated-field.rs
+++ b/builder/tests/07-repeated-field.rs
@@ -7,6 +7,10 @@
 // and should use the word given in the string literal as the name for the
 // corresponding builder method which accepts one vector element at a time.
 //
+// This new "one at a time" builder method might have the same name as the
+// original "all at once" builder method.  The easiest way to handle this is
+// to produce one method or the other, not both.
+//
 // In order for the compiler to know that these builder attributes are
 // associated with your macro, they must be declared at the entry point of the
 // derive macro. Otherwise the compiler will report them as unrecognized


### PR DESCRIPTION
It's easy to miss the fact that the test case includes a field named
"env" and a #[builder(each = "env")] attribute.

This will cause a "duplicate definitions with name 'env'" error if the
macro produces two methods.

Hopefully addresses #26 .  Feel free to tweak the language.