### PR TITLE
sorted: update 02-not-enum.stderr

### DIFF
--- a/sorted/tests/02-not-enum.stderr
+++ b/sorted/tests/02-not-enum.stderr
@@ -3,3 +3,5 @@ error: expected enum or match expression
    |
 31 | #[sorted]
    | ^^^^^^^^^
+   |
+   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
On my machine I am seeing an additional message on trying to implement the second test for sorted.

My implementation

```rs
#[proc_macro_attribute]
pub fn sorted(args: TokenStream, input: TokenStream) -> TokenStream {
    let item = parse_macro_input!(input as Item);

    match item {
        Item::Enum(item) => {
            let stream = quote! { #item };
            stream.into()
        }
        _ => Error::new_spanned(
            TokenStream2::from(args),
            "expected enum or match expression",
        )
        .to_compile_error()
        .into(),
    }
}
```

I have tried other things also, still getting the additional line in the error for attribute macro.

__rustc --version__ output:

```
rustc 1.45.2 (d3fb005a3 2020-07-31)
```

Not sure if I am doing something wrong. Also the additional line specifically mentions attribute macro, and so far I have only implemented the derive and functional macro exercises from before