### PR TITLE
Add Dockerfile for container image generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+from docker.io/library/rust
+
+RUN apt update && apt upgrade
+RUN cargo install cargo-expand
+RUN rustup default nightly


### PR DESCRIPTION
I completed the `builder` part of the workshop, and I was using a container image to run the code. I figured that his could come in handy in the future for new users.

By having a container image that contains all the required (or
recommended) software to complete the workshop, users can focus more on
the tasks instead of the setup.

Additionally if someone just wants to give macros a quick go, they
won't have to "pollute" their system with extra packages.