### PR TITLE
Update seq project to paste using ~ instead of #

### DIFF
--- a/seq/tests/04-paste-ident.rs
+++ b/seq/tests/04-paste-ident.rs
@@ -1,7 +1,7 @@
 // One of the big things callers will want to do with the sequential indices N
 // is use them as part of an identifier, like f0 f1 f2 etc.
 //
-// Implement some logic to paste together any Ident followed by `#` followed by
+// Implement some logic to paste together any Ident followed by `~` followed by
 // our loop variable into a single concatenated identifier.
 //
 // The invocation below will expand to:
@@ -10,8 +10,8 @@
 //     fn f2() -> u64 { 2 * 2 }
 //     fn f3() -> u64 { 3 * 2 }
 //
-// Optionally, also support more flexible arrangements like `f#N#_suffix` ->
-// f0_suffix f1_suffix etc, though the test suite only requires `prefix#N` so
+// Optionally, also support more flexible arrangements like `f~N~_suffix` ->
+// f0_suffix f1_suffix etc, though the test suite only requires `prefix~N` so
 // you will need to add your own tests for this feature.
 //
 //
@@ -23,7 +23,7 @@
 use seq::seq;
 
 seq!(N in 1..4 {
-    fn f#N () -> u64 {
+    fn f~N () -> u64 {
         N * 2
     }
 });

--- a/seq/tests/05-repeat-section.rs
+++ b/seq/tests/05-repeat-section.rs
@@ -5,7 +5,7 @@
 //
 //     enum Interrupt {
 //         seq!(N in 0..16 {
-//             Irq#N,
+//             Irq~N,
 //         });
 //     }
 //
@@ -34,7 +34,7 @@ seq!(N in 0..16 {
     #[derive(Copy, Clone, PartialEq, Debug)]
     enum Interrupt {
         #(
-            Irq#N,
+            Irq~N,
         )*
     }
 });

--- a/seq/tests/07-inclusive-range.rs
+++ b/seq/tests/07-inclusive-range.rs
@@ -6,7 +6,7 @@ use seq::seq;
 seq!(N in 16..=20 {
     enum E {
         #(
-            Variant#N,
+            Variant~N,
         )*
     }
 });

--- a/seq/tests/08-ident-span.rs
+++ b/seq/tests/08-ident-span.rs
@@ -6,24 +6,24 @@
 // The invocation below expands to code that mentions a value Missing0 which
 // does not exist. When the compiler reports that it "cannot find value
 // Missing0", we would like for the error to point directly to where the user
-// wrote `Missing#N` in their macro input.
+// wrote `Missing~N` in their macro input.
 //
 //     error[E0425]: cannot find value `Missing0` in this scope
 //       |
-//       |         let _ = Missing#N;
+//       |         let _ = Missing~N;
 //       |                 ^^^^^^^ not found in this scope
 //
 // For this test to pass, ensure that the pasted-together identifier is created
 // using the Span of the identifier written by the caller.
 //
 // If you are using a nightly toolchain, there is a nightly-only method called
-// Span::join which would allow joining the three spans of `Missing`, `#`, `N`
+// Span::join which would allow joining the three spans of `Missing`, `~`, `N`
 // so that the resulting error is as follows, but I would recommend not
 // bothering with this for the purpose of this project while it is unstable.
 //
 //     error[E0425]: cannot find value `Missing0` in this scope
 //       |
-//       |         let _ = Missing#N;
+//       |         let _ = Missing~N;
 //       |                 ^^^^^^^^^ not found in this scope
 //
 
@@ -31,6 +31,6 @@ use seq::seq;
 
 seq!(N in 0..1 {
     fn main() {
-        let _ = Missing#N;
+        let _ = Missing~N;
     }
 });

--- a/seq/tests/08-ident-span.stderr
+++ b/seq/tests/08-ident-span.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find value `Missing0` in this scope
   --> tests/08-ident-span.rs:34:17
    |
-34 |         let _ = Missing#N;
+34 |         let _ = Missing~N;
    |                 ^^^^^^^ not found in this scope


### PR DESCRIPTION
Required for #44 because `Variant#N` is no longer legal syntax in 2021 edition. Change to `Variant~N`.