### PR TITLE
Update project templates to 2021 edition

### DIFF
--- a/.template/Cargo.toml
+++ b/.template/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = ""
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 autotests = false
 publish = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proc-macro-workshop"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [workspace]

--- a/bitfield/Cargo.toml
+++ b/bitfield/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitfield"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 autotests = false
 publish = false
 

--- a/bitfield/impl/Cargo.toml
+++ b/bitfield/impl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitfield-impl"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "derive_builder"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 autotests = false
 publish = false
 

--- a/debug/Cargo.toml
+++ b/debug/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "derive_debug"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 autotests = false
 publish = false
 

--- a/seq/Cargo.toml
+++ b/seq/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "seq"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 autotests = false
 publish = false
 

--- a/sorted/Cargo.toml
+++ b/sorted/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sorted"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 autotests = false
 publish = false
 


### PR DESCRIPTION
Closes #44. Following #45 I believe the rest of the projects should work unchanged.