### PR TITLE
sorted test4 suppress warning: unused import

### DIFF
--- a/sorted/tests/04-variants-with-data.rs
+++ b/sorted/tests/04-variants-with-data.rs
@@ -1,7 +1,7 @@
 // This test is similar to the previous where want to ensure that the macro
 // correctly generates an error when the input enum is out of order, but this
 // time it is using an enum that also has data associated with each variant.
-
+#![allow(unused)] 
 use sorted::sorted;
 
 use std::env::VarError;


### PR DESCRIPTION
Should we suppress this warning, let the test passed?

cargo version: cargo 1.82.0 (8f40fc59f 2024-08-21)
rustc version: rustc 1.82.0 (f6e511eec 2024-10-15)



![Screenshot 2024-11-02 165233](https://github.com/user-attachments/assets/1182ee0c-d904-44c0-8224-dafafdf23397)